### PR TITLE
Robert/handle json value

### DIFF
--- a/tap_netsuite/sync.py
+++ b/tap_netsuite/sync.py
@@ -9,7 +9,6 @@ from jsonpath_ng import jsonpath, parse
 import json
 from zeep.helpers import serialize_object
 import types
-from collections import OrderedDict
 import json
 LOGGER = singer.get_logger()
 

--- a/tap_netsuite/sync.py
+++ b/tap_netsuite/sync.py
@@ -24,8 +24,7 @@ def get_internal_name_by_name(ns, stream):
 
 def transform_dict(record: dict):
     for k, v, in record.items():
-        eval_v = eval(v)
-        if isinstance(eval_v, OrderedDict) or isinstance(eval_v, dict):
+        if isinstance(v, str) and v.startswith("{"):
             record[k] = json.loads(v)
         # if isinstance(v, str) and "OrderedDict(" in v:
         #     value = eval(v)

--- a/tap_netsuite/sync.py
+++ b/tap_netsuite/sync.py
@@ -25,8 +25,8 @@ def get_internal_name_by_name(ns, stream):
 def transform_dict(record: dict):
     for k, v, in record.items():
         if isinstance(v, str) and "{" in v:
-            # record[k] = json.dumps(eval(v)) # will write as json string
-            record[k] = eval(v) # will write as json object
+            record[k] = json.dumps(eval(v)) # will write as json string
+            # record[k] = eval(v) # will write as json object
         # if isinstance(v, OrderedDict):
         #     record[k] = json.dumps(v)
         # if isinstance(v, str) and "OrderedDict(" in v:

--- a/tap_netsuite/sync.py
+++ b/tap_netsuite/sync.py
@@ -26,12 +26,15 @@ def transform_dict(record: dict):
     for k, v, in record.items():
         if isinstance(v, str) and v.startswith("{"):
             record[k] = json.loads(v)
+        if isinstance(v, dict):
+            record[k] = json.dumps(v)
         # if isinstance(v, str) and "OrderedDict(" in v:
         #     value = eval(v)
         #     record[k] = json.dumps(value)
         # if isinstance(v, str) and isinstance(v,eval(v)):
             
     return record
+
 
 def transform_data_hook(ns, stream):
     def pre_hook(data, typ, schema):

--- a/tap_netsuite/sync.py
+++ b/tap_netsuite/sync.py
@@ -24,9 +24,9 @@ def get_internal_name_by_name(ns, stream):
 
 def transform_dict(record: dict):
     for k, v, in record.items():
-        if isinstance(v, str) and v.startswith("{"):
+        if isinstance(v, str) and "OrderedDict" in v:
             record[k] = json.loads(v)
-        if isinstance(v, dict):
+        if isinstance(v, OrderedDict):
             record[k] = json.dumps(v)
         # if isinstance(v, str) and "OrderedDict(" in v:
         #     value = eval(v)
@@ -131,7 +131,7 @@ def sync_records(ns, catalog_entry, state, counter):
         for rec in page:
             counter.increment()
             with Transformer() as transformer:
-                rec = transformer.transform(serialize_object(rec, target_cls=dict), schema, catalog_metadata)
+                rec = transformer.transform(serialize_object(rec), schema, catalog_metadata)
                 rec = transform_dict(rec)
             singer.write_message(
                 singer.RecordMessage(

--- a/tap_netsuite/sync.py
+++ b/tap_netsuite/sync.py
@@ -25,7 +25,7 @@ def get_internal_name_by_name(ns, stream):
 def transform_dict(record: dict):
     for k, v, in record.items():
         if isinstance(v, str) and "OrderedDict" in v:
-            record[k] = json.loads(v)
+            record[k] = json.loads(eval(v))
         if isinstance(v, OrderedDict):
             record[k] = json.dumps(v)
         # if isinstance(v, str) and "OrderedDict(" in v:

--- a/tap_netsuite/sync.py
+++ b/tap_netsuite/sync.py
@@ -26,7 +26,9 @@ def get_internal_name_by_name(ns, stream):
 def transform_str_dict(record: dict):
     for k, v, in record.items():
         if isinstance(v, str) and v.startswith("{"):
+            #record[k] = json.dumps(eval(v))
             record[k] = dict(eval(v))
+
     return record
 
 

--- a/tap_netsuite/sync.py
+++ b/tap_netsuite/sync.py
@@ -22,11 +22,11 @@ def get_internal_name_by_name(ns, stream):
 
     return to_return
 
-def transform_dict(record: dict):
+
+def transform_str_dict(record: dict):
     for k, v, in record.items():
-        if isinstance(v, str) and "{" in v:
-            #record[k] = json.dumps(eval(v)) # will write as json string
-            record[k] = dict(eval(v)) # will write as json object
+        if isinstance(v, str) and v.startswith("{"):
+            record[k] = dict(eval(v))
     return record
 
 
@@ -126,7 +126,7 @@ def sync_records(ns, catalog_entry, state, counter):
             counter.increment()
             with Transformer() as transformer:
                 rec = transformer.transform(serialize_object(rec, target_cls=dict), schema, catalog_metadata)
-                rec = transform_dict(rec)
+                rec = transform_str_dict(rec)
             singer.write_message(
                 singer.RecordMessage(
                     stream=(

--- a/tap_netsuite/sync.py
+++ b/tap_netsuite/sync.py
@@ -25,15 +25,8 @@ def get_internal_name_by_name(ns, stream):
 def transform_dict(record: dict):
     for k, v, in record.items():
         if isinstance(v, str) and "{" in v:
-            record[k] = json.dumps(eval(v)) # will write as json string
-            # record[k] = eval(v) # will write as json object
-        # if isinstance(v, OrderedDict):
-        #     record[k] = json.dumps(v)
-        # if isinstance(v, str) and "OrderedDict(" in v:
-        #     value = eval(v)
-        #     record[k] = json.dumps(value)
-        # if isinstance(v, str) and isinstance(v,eval(v)):
-            
+            #record[k] = json.dumps(eval(v)) # will write as json string
+            record[k] = dict(eval(v)) # will write as json object
     return record
 
 

--- a/tap_netsuite/sync.py
+++ b/tap_netsuite/sync.py
@@ -26,8 +26,7 @@ def get_internal_name_by_name(ns, stream):
 def transform_str_dict(record: dict):
     for k, v, in record.items():
         if isinstance(v, str) and v.startswith("{"):
-            #record[k] = json.dumps(eval(v))
-            record[k] = dict(eval(v))
+            record[k] = json.dumps(eval(v))
 
     return record
 

--- a/tap_netsuite/sync.py
+++ b/tap_netsuite/sync.py
@@ -24,10 +24,11 @@ def get_internal_name_by_name(ns, stream):
 
 def transform_dict(record: dict):
     for k, v, in record.items():
-        if isinstance(v, str) and "OrderedDict" in v:
-            record[k] = json.loads(eval(v))
-        if isinstance(v, OrderedDict):
-            record[k] = json.dumps(v)
+        if isinstance(v, str) and "{" in v:
+            # record[k] = json.dumps(eval(v)) # will write as json string
+            record[k] = eval(v) # will write as json object
+        # if isinstance(v, OrderedDict):
+        #     record[k] = json.dumps(v)
         # if isinstance(v, str) and "OrderedDict(" in v:
         #     value = eval(v)
         #     record[k] = json.dumps(value)
@@ -131,7 +132,7 @@ def sync_records(ns, catalog_entry, state, counter):
         for rec in page:
             counter.increment()
             with Transformer() as transformer:
-                rec = transformer.transform(serialize_object(rec), schema, catalog_metadata)
+                rec = transformer.transform(serialize_object(rec, target_cls=dict), schema, catalog_metadata)
                 rec = transform_dict(rec)
             singer.write_message(
                 singer.RecordMessage(


### PR DESCRIPTION
Handle the results of serialize_object() that returns a dict that contains values that are dict string.  Evaluate those strings as dicts and the json dumps to obtain validate json format for the python dictionary values where this occurs.

A single record result will look as follows:

```{
    "baseCurrency": "{\"name\": \"US Dollar\", \"internalId\": \"1\", \"externalId\": null, \"type\": null}",
    "transactionCurrency": "{\"name\": \"US Dollar\", \"internalId\": \"1\", \"externalId\": null, \"type\": null}",
    "exchangeRate": 1,
    "effectiveDate": "1969-12-31 21:00:00-08:00",
    "internalId": "1"
}